### PR TITLE
updated swagger-ui to version 3.0.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,8 @@ RUN apk add --update nginx openssl curl bash
 
 # setup for this version of nginx
 RUN mkdir -p /run/nginx/
-ENV NGINX_ROOT=/var/lib/nginx/html
+ENV NGINX_ROOT=/usr/share/nginx/html
+RUN mkdir -p $NGINX_ROOT
 
 # make directories used by the yaml merging
 RUN mkdir -p /src /target
@@ -71,7 +72,8 @@ RUN mkdir -p /src /target
 ##########################
 # grab the swagger-ui
 # Inspired by https://hub.docker.com/r/schickling/swagger-ui/
-ENV SWAGGER_VERSION=2.2.8
+#ENV SWAGGER_VERSION=2.2.8
+ENV SWAGGER_VERSION=3.0.21
 ENV SWAGGER_UI_FOLDER=swagger-ui-$SWAGGER_VERSION
 
 # In the index.html file, Change the default swagger file to be 'swagger.yaml'

--- a/run.sh
+++ b/run.sh
@@ -21,7 +21,7 @@
 ########
 initialize_variables() {
     # where nginx HTML file are placed
-    NGINX_ROOT=/var/lib/nginx/html/
+    NGINX_ROOT=/usr/share/nginx/html/
 
     # where the source yaml,yml,json files are placed
     SOURCE_YAML_DIRECTORY=/source_yaml/
@@ -130,7 +130,7 @@ start_nginx() {
     echo "Turning off validator from swagger-ui"
     
     # Turn off the validator from the swagger-ui
-    sed -i '54i    validatorUrl : null,' $NGINX_ROOT/index.html
+    sed -i '79i    validatorUrl : null,' $NGINX_ROOT/index.html
     
     echo ""
     echo "Starting nginx"


### PR DESCRIPTION
The nginx root of swagger-ui nginx.conf changed.
The linenumber for the sed command (to disable validator) changed.